### PR TITLE
Fix to expose missing types

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,8 +31,10 @@
   "type": "module",
   "main": "index.js",
   "files": [
-    "index.js"
+    "index.js",
+    "index.d.ts"
   ],
+  "types": "index.d.ts",
   "dependencies": {
     "@types/estree-jsx": "^0.0.1",
     "estree-util-visit": "^1.0.0",

--- a/test.js
+++ b/test.js
@@ -38,7 +38,6 @@ test('esast-util-from-estree', (t) => {
                 end: {line: 1, column: 12, offset: 11}
               }
             },
-            // @ts-expect-error: TS is wrong.
             arguments: [
               {
                 type: 'Literal',


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/syntax-tree/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/syntax-tree/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/syntax-tree/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Asyntax-tree&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

This PR exposes the type declaration file in `package.json`, to make sure it is included in the published version of the package on NPM.

I've removed a `@ts-expect-error` directive in `test.js` where no error was being thrown by TS, except about the directive itself.

<!--do not edit: pr-->
